### PR TITLE
Update Readme and fix doc typo for Menu Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ Menu::make('MyNavBar', function($menu){
 
   $menu->add('Home',     array('route'  => 'home.page', 'class' => 'navbar navbar-home', 'id' => 'home'));
   
-  $menu->group(array('style' => 'padding: 0', 'data-role' => 'navigation') function($m){
+  $menu->group(array('style' => 'padding: 0', 'data-role' => 'navigation'), function($m){
     
         $m->add('About',    array('route'  => 'page.about', 'class' => 'navbar navbar-about dropdown'));
         $m->add('services', array('action' => 'ServicesController@index'));


### PR DESCRIPTION
Update Readme and fix doc typo for Menu Groups: 

https://github.com/lavary/laravel-menu#menu-groups

Here I add a comma.